### PR TITLE
Prefer Wayland window manager

### DIFF
--- a/net.openra.OpenRA.yaml
+++ b/net.openra.OpenRA.yaml
@@ -8,9 +8,9 @@ rename-icon: net.openra.OpenRA-ra
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.dotnet6
 finish-args:
-  - --socket=x11
-  - --share=ipc
   - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
   - --socket=pulseaudio
   - --device=all
   - --share=network


### PR DESCRIPTION
We support Wayland on AppImage since https://github.com/OpenRA/OpenRA/pull/20914 so it is about time to enable here. This reduces the warnings displayed on https://flathub.org/apps/net.openra.OpenRA